### PR TITLE
Network issue after dpdk vrouter restart

### DIFF
--- a/patches/trusty/qemu/CODE-vhost-user-invalid-access.patch
+++ b/patches/trusty/qemu/CODE-vhost-user-invalid-access.patch
@@ -1,0 +1,31 @@
+diff -Naur build/qemu-2.5+dfsg/net/vhost-user.c qemu-2.5+dfsg/net/vhost-user.c
+--- build/qemu-2.5+dfsg/net/vhost-user.c	2017-07-06 16:17:24.799928000 -0700
++++ qemu-2.5+dfsg/net/vhost-user.c	2017-07-10 12:06:57.505173000 -0700
+@@ -178,6 +178,8 @@
+     queues = qemu_find_net_clients_except(name, ncs,
+                                           NET_CLIENT_OPTIONS_KIND_NIC,
+                                           MAX_QUEUE_NUM);
++    assert(queues < MAX_QUEUE_NUM);
++ 
+     s = DO_UPCAST(VhostUserState, nc, ncs[0]);
+     trace_vhost_user_event(s->chr->label, event);
+     switch (event) {
+@@ -212,6 +214,9 @@
+     VhostUserState *s;
+     int i;
+ 
++    assert(name);
++    assert(queues > 0);
++
+     for (i = 0; i < queues; i++) {
+         nc = qemu_new_net_client(&net_vhost_user_info, peer, device, name);
+ 
+@@ -225,7 +230,7 @@
+     }
+ 
+     qemu_chr_add_handlers(chr, net_vhost_user_can_receive, NULL,
+-                          net_vhost_user_event, (void*)name);
++                          net_vhost_user_event, nc[0].name);
+ 
+     return 0;
+ }

--- a/patches/trusty/qemu/DEBIAN-Contrail-version.patch
+++ b/patches/trusty/qemu/DEBIAN-Contrail-version.patch
@@ -2,7 +2,13 @@ diff --git a/debian/changelog b/debian/changelog
 index 594fac7..91783cf 100644
 --- a/debian/changelog
 +++ b/debian/changelog
-@@ -1,3 +1,9 @@
+@@ -1,3 +1,15 @@
++qemu (1:2.5+dfsg-5ubuntu10.2~cloud0+contrail2) UNRELEASED; urgency=medium
++
++  * Contrail patches for invalid access in vhost-user code
++
++ -- Jeya ganesh babu J <jjeya@juniper.net>  Mon, 10 Jul 2017 11:55:46 -0800
++
 +qemu (1:2.5+dfsg-5ubuntu10.2~cloud0+contrail1) UNRELEASED; urgency=medium
 +
 +  * Contrail patches for vhost-user receive and chardev reconnect


### PR DESCRIPTION
Partial-Bug: #1604179
Issue in the 2.5 version of qemu. Pulled in a patch from 2.6
to fix this. This will avoid an invalid access as well.